### PR TITLE
Replace single member interface with delegate

### DIFF
--- a/src/Assent/Configuration.cs
+++ b/src/Assent/Configuration.cs
@@ -7,7 +7,7 @@ namespace Assent
 {
     public interface IConfiguration<T>
     {
-        INamer Namer { get; }
+        GetName Namer { get; }
         IReporter Reporter { get; }
         T Extension { get; }
         IReaderWriter<T> ReaderWriter { get; }
@@ -25,7 +25,7 @@ namespace Assent
             Comparer = new DefaultStringComparer(true);
             Extension = "txt";
             ReaderWriter = new StringReaderWriter();
-            Namer = new DefaultNamer();
+            Namer = new DefaultNamer().GetName;
             Sanitiser = new NullSanitiser<string>();
             IsInteractive = !"true".Equals(Environment.GetEnvironmentVariable("AssentNonInteractive"), StringComparison.OrdinalIgnoreCase);
         }
@@ -41,7 +41,7 @@ namespace Assent
             IsInteractive = basedOn.IsInteractive;
         }
 
-        public INamer Namer { get; private set; }
+        public GetName Namer { get; private set; }
         public IReporter Reporter { get; private set; }
         public string Extension { get; private set; }
         public IReaderWriter<string> ReaderWriter { get; private set; }
@@ -50,7 +50,7 @@ namespace Assent
 
         public bool IsInteractive { get; private set; }
 
-        public Configuration UsingNamer(INamer namer)
+        public Configuration UsingNamer(GetName namer)
         {
             return new Configuration(this)
             {
@@ -62,7 +62,7 @@ namespace Assent
         {
             return new Configuration(this)
             {
-                Namer = new FixedNamer(name)
+                Namer = new FixedNamer(name).GetName
             };
         }
 

--- a/src/Assent/Configuration.cs
+++ b/src/Assent/Configuration.cs
@@ -7,7 +7,7 @@ namespace Assent
 {
     public interface IConfiguration<T>
     {
-        GetName Namer { get; }
+        Func<TestMetadata, string> Namer { get; }
         IReporter Reporter { get; }
         T Extension { get; }
         IReaderWriter<T> ReaderWriter { get; }
@@ -41,7 +41,7 @@ namespace Assent
             IsInteractive = basedOn.IsInteractive;
         }
 
-        public GetName Namer { get; private set; }
+        public Func<TestMetadata, string> Namer { get; private set; }
         public IReporter Reporter { get; private set; }
         public string Extension { get; private set; }
         public IReaderWriter<string> ReaderWriter { get; private set; }
@@ -50,7 +50,7 @@ namespace Assent
 
         public bool IsInteractive { get; private set; }
 
-        public Configuration UsingNamer(GetName namer)
+        public Configuration UsingNamer(Func<TestMetadata, string> namer)
         {
             return new Configuration(this)
             {

--- a/src/Assent/Engine.cs
+++ b/src/Assent/Engine.cs
@@ -9,7 +9,7 @@ namespace Assent
         internal static void Execute(IConfiguration<T> configuration, TestMetadata metadata, T recieved)
         {
             recieved = configuration.Sanitiser.Sanatise(recieved);
-            var name = configuration.Namer.GetName(metadata);
+            var name = configuration.Namer(metadata);
             var approvedFileName = name + ".approved." + configuration.Extension;
             var receivedFileName = name + ".received." + configuration.Extension;
 

--- a/src/Assent/INamer.cs
+++ b/src/Assent/INamer.cs
@@ -1,4 +1,0 @@
-﻿namespace Assent
-{
-    public delegate string GetName(TestMetadata metadata);
-}

--- a/src/Assent/INamer.cs
+++ b/src/Assent/INamer.cs
@@ -1,7 +1,4 @@
 ﻿namespace Assent
 {
-    public interface INamer
-    {
-        string GetName(TestMetadata metadata);
-    }
+    public delegate string GetName(TestMetadata metadata);
 }

--- a/src/Assent/Namers/DefaultNamer.cs
+++ b/src/Assent/Namers/DefaultNamer.cs
@@ -2,7 +2,7 @@
 
 namespace Assent.Namers
 {
-    public class DefaultNamer : INamer
+    public class DefaultNamer
     {
         public virtual string GetName(TestMetadata metadata)
         {

--- a/src/Assent/Namers/FixedNamer.cs
+++ b/src/Assent/Namers/FixedNamer.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Returns the specified name without modification
     /// </summary>
-    public class FixedNamer : INamer
+    public class FixedNamer
     {
         private readonly string _name;
 

--- a/src/Assent/Namers/SubdirectoryNamer.cs
+++ b/src/Assent/Namers/SubdirectoryNamer.cs
@@ -7,7 +7,7 @@ namespace Assent.Namers
     /// An optional postfix can be specified.
     /// eg filename: `subdirectory/class.method.postfix`
     /// </summary>
-    public class SubdirectoryNamer : INamer
+    public class SubdirectoryNamer
     {
         private readonly string _subdirectory;
         private readonly string _postfix;


### PR DESCRIPTION
When you want to customize how snapshots are named, you are currently required to create a whole new class and implement the interface and etc. It would be much easier if you could simply supply a `Func<TestMetaData, string>` in the form: `metadata => Path.GetDirectoryName(metadata.FileName) + "foo"`.

To this end I've eliminated the single member `INamer` interface and replaced it with an equivalent delegate. The existing implementations of `INamer` are more or less unchanged: where before the user was passing `.UsingNamer(new FixedNamer("foo"))` they simply have to pass `.UsingNamer(new FixedNamer("foo").GetName)`, or more simply `.UsingNamer(_ => "foo")`.

Beware that this would be a **breaking** change though. I wasn't 100% sure where in the code the version needs to be bumped.