### PR TITLE
Add path for local vs code install

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
+++ b/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
@@ -12,7 +12,8 @@ namespace Assent.Reporters.DiffPrograms
             {
                 Environment.GetEnvironmentVariable("ProgramFiles"),
                 Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
-                Environment.GetEnvironmentVariable("ProgramW6432")
+                Environment.GetEnvironmentVariable("ProgramW6432"),
+                Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "Programs")
             }
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Distinct()


### PR DESCRIPTION
As of [July 2018 (version 1.26)](https://code.visualstudio.com/updates/v1_26) VS Code now recommends a local install : https://code.visualstudio.com/docs/setup/windows.

I couldn't find a single var for C:\Users\{user}\AppData\Local\Programs, so I built the path from env:LocalAppData.

