### PR TITLE
Added /usr/bin/code for potential VSCode Paths

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
@@ -18,6 +18,7 @@ namespace Assent.Reporters.DiffPrograms
             else
             {
                 paths.Add("/usr/local/bin/code");
+                paths.Add("/usr/bin/code");
                 paths.Add("/snap/bin/code");
             }
             DefaultSearchPaths = paths;


### PR DESCRIPTION
VSCode installs into /use/bin/code instead of /usr/local/bin/code now 
https://superuser.com/a/1376858