### PR TITLE
Launch beyond compare in solo mode

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
@@ -39,5 +39,10 @@ namespace Assent.Reporters.DiffPrograms
         {
         }
 
+        protected override string CreateProcessStartArgs(string receivedFile, string approvedFile)
+        {
+            var defaultArgs = base.CreateProcessStartArgs(receivedFile, approvedFile);
+            return $"{defaultArgs} /solo";
+        }
     }
 }


### PR DESCRIPTION
So that if it's already open, it doesn't try and add as a tab.
When it was adding as a tab on the existing process, it was exiting the new beyond compare process, and causing assent to cleanup the received file & failing the test early.