### PR TITLE
Add default macOS install location

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
@@ -20,6 +20,7 @@ namespace Assent.Reporters.DiffPrograms
                 paths.Add("/usr/local/bin/code");
                 paths.Add("/usr/bin/code");
                 paths.Add("/snap/bin/code");
+                paths.Add("/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code");
             }
             DefaultSearchPaths = paths;
         }


### PR DESCRIPTION
The default VS Code install location on macOS is now: `Applications/Visual Studio Code.app/Contents/Resources/app/bin`
(see [documentation](https://code.visualstudio.com/docs/setup/mac))

This fixes `VsCodeDiffProgram` on macOS.