### PR TITLE
Uses correct argument character for BC on non-windows platforms

### DIFF
--- a/src/Assent.Tests/Assent.Tests.csproj
+++ b/src/Assent.Tests/Assent.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">netcoreapp1.1;netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp1.1;netcoreapp2.0;</TargetFrameworks>
     <AssemblyName>Assent.Tests</AssemblyName>
     <PackageId>Assent.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/Assent/Assent.csproj
+++ b/src/Assent/Assent.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">netstandard1.3;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Assent</AssemblyName>
     <PackageId>Assent</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
@@ -42,7 +42,8 @@ namespace Assent.Reporters.DiffPrograms
         protected override string CreateProcessStartArgs(string receivedFile, string approvedFile)
         {
             var defaultArgs = base.CreateProcessStartArgs(receivedFile, approvedFile);
-            return $"{defaultArgs} /solo";
+            var argChar = DiffReporter.IsWindows ? "/" : "-";
+            return $"{defaultArgs} {argChar}solo" ;
         }
     }
 }


### PR DESCRIPTION
- Caters to non-windows usages of BeyondCompare on windows
- Tweaks the `.csproj` files to allow building on non-windows platforms 

Tested on Ubuntu 19.10