### PR TITLE
Swap VSCode diff args to have approved as "base"

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
@@ -39,7 +39,7 @@ namespace Assent.Reporters.DiffPrograms
 
         protected override string CreateProcessStartArgs(string receivedFile, string approvedFile)
         {
-            return $"--diff --wait --new-window \"{receivedFile}\" \"{approvedFile}\"";
+            return $"--diff --wait --new-window \"{approvedFile}\" \"{receivedFile}\"";
         }
     }
 }


### PR DESCRIPTION
The approved string should be the "base" file to compare so it should be passed as the first file arg:

```shell
$ code --diff --wait --new-window base.txt new.txt
```

![code-diff-base-new](https://user-images.githubusercontent.com/358122/99026512-1f189380-2539-11eb-89de-3f9c320e9f9c.png)
