### PR TITLE
Add support for a custom approval filename suffix

### DIFF
--- a/src/Assent.Tests/EndToEnd/CustomSuffixScenario.cs
+++ b/src/Assent.Tests/EndToEnd/CustomSuffixScenario.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Assent.Tests.EndToEnd
+{
+    public class CustomSuffixScenario : BaseScenario
+    {
+        private Action _action;
+        private readonly string _receivedPath = Path.Join(GetTestDirectory(), "EndToEnd", $"{nameof(CustomSuffixScenario)}.{nameof(WhenTheTestIsRun)}.reçu.txt");
+        private readonly string _approvedPath = Path.Join(GetTestDirectory(), "EndToEnd", $"{nameof(CustomSuffixScenario)}.{nameof(WhenTheTestIsRun)}.approuvé.txt");
+
+        public void AndGivenCustomApprovalAndReceivedSuffixes()
+        {
+            Configuration = Configuration
+                .UsingApprovalFileNameSuffix(".approuvé")
+                .UsingReceivedFileNameSuffix(".reçu");
+        }
+        
+        public void AndGivenTheApprovedFileMatches()
+        {
+            ReaderWriter.Files[_approvedPath] = "Foo";
+        }
+
+        public void WhenTheTestIsRun()
+        {
+            _action = () => this.Assent("Foo", Configuration);
+        }
+
+        public void ThenAnExceptionIsNotThrown()
+        {
+            _action.ShouldNotThrow();
+        }
+
+        public void AndThenTheReceivedFileIsNotWritten()
+        {
+            ReaderWriter.Files.Keys.Should().NotContain(_receivedPath);
+        }
+
+        public void AndThenTheReporterIsNotLaunched()
+        {
+            Reporter.DidNotReceiveWithAnyArgs().Report(_receivedPath, _approvedPath);
+        }
+    }
+}

--- a/src/Assent/Configuration.cs
+++ b/src/Assent/Configuration.cs
@@ -9,6 +9,8 @@ namespace Assent
     {
         INamer Namer { get; }
         IReporter Reporter { get; }
+        T ApprovalFileNameSuffix { get; }
+        T ReceivedFileNameSuffix { get; }
         T Extension { get; }
         IReaderWriter<T> ReaderWriter { get; }
         IComparer<T> Comparer { get; }
@@ -24,6 +26,8 @@ namespace Assent
             Reporter = new DiffReporter();
             Comparer = new DefaultStringComparer(true);
             Extension = "txt";
+            ApprovalFileNameSuffix = ".approved";
+            ReceivedFileNameSuffix = ".received";
             ReaderWriter = new StringReaderWriter();
             Namer = new DefaultNamer();
             Sanitiser = new NullSanitiser<string>();
@@ -36,6 +40,8 @@ namespace Assent
             Comparer = basedOn.Comparer;
             Reporter = basedOn.Reporter;
             Extension = basedOn.Extension;
+            ApprovalFileNameSuffix = basedOn.ApprovalFileNameSuffix;
+            ReceivedFileNameSuffix = basedOn.ReceivedFileNameSuffix;
             ReaderWriter = basedOn.ReaderWriter;
             Sanitiser = basedOn.Sanitiser;
             IsInteractive = basedOn.IsInteractive;
@@ -44,6 +50,8 @@ namespace Assent
         public INamer Namer { get; private set; }
         public IReporter Reporter { get; private set; }
         public string Extension { get; private set; }
+        public string ApprovalFileNameSuffix { get; private set; }
+        public string ReceivedFileNameSuffix { get; private set; }
         public IReaderWriter<string> ReaderWriter { get; private set; }
         public IComparer<string> Comparer { get; private set; }
         public ISanitiser<string> Sanitiser { get; private set; }
@@ -63,6 +71,22 @@ namespace Assent
             return new Configuration(this)
             {
                 Namer = new DelegateNamer(namer)
+            };
+        }
+        
+        public Configuration UsingApprovalFileNameSuffix(string approvalFileNameSuffix)
+        {
+            return new Configuration(this)
+            {
+                ApprovalFileNameSuffix = approvalFileNameSuffix
+            };
+        }
+        
+        public Configuration UsingReceivedFileNameSuffix(string receivedFileNameSuffix)
+        {
+            return new Configuration(this)
+            {
+                ReceivedFileNameSuffix = receivedFileNameSuffix
             };
         }
 

--- a/src/Assent/Engine.cs
+++ b/src/Assent/Engine.cs
@@ -10,8 +10,8 @@ namespace Assent
         {
             recieved = configuration.Sanitiser.Sanatise(recieved);
             var name = configuration.Namer.GetName(metadata);
-            var approvedFileName = name + ".approved." + configuration.Extension;
-            var receivedFileName = name + ".received." + configuration.Extension;
+            var approvedFileName = $"{name}{configuration.ApprovalFileNameSuffix}.{configuration.Extension}";
+            var receivedFileName = $"{name}{configuration.ReceivedFileNameSuffix}.{configuration.Extension}";
 
             var result = Compare(configuration, receivedFileName, approvedFileName, recieved);
             if (!result.Passed)


### PR DESCRIPTION
This supports scenarios where we need to verify against a fixed filename that we cant (or don't want to) change.

The scenario I'm facing is where I need to approve against a file in the repo that is used for a different purpose (in this case, backstage info), so it doesn't look right to have `.approved` in the name.

(A side effect is this also supports users who want to use non-english filenames better)    

Note: I considered adding an `INamerV2` interface and adding those properties on there, but thought this was a maginally less invasive/less risk approach. Happy to go down that route instead though if you think it better.