### PR TITLE
Add homebrew path for BeyondCompare

### DIFF
--- a/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
@@ -24,6 +24,7 @@ namespace Assent.Reporters.DiffPrograms
             {
                 paths.Add("/usr/bin/bcompare");
                 paths.Add("/usr/local/bin/bcompare");
+                paths.Add("/opt/homebrew/bin/bcompare");
             }
             DefaultSearchPaths = paths;
         }


### PR DESCRIPTION
Adds the default homebrew install path for BeyondCompare on mac.

This allows it to work without needing a synlink added
```
sudo ln -s /opt/homebrew/bin/bcompare /usr/local/bin/bcompare
```