### PR TITLE
Improve line ending error messages

### DIFF
--- a/src/Assent.Tests/DefaultStringComparerTests.cs
+++ b/src/Assent.Tests/DefaultStringComparerTests.cs
@@ -8,11 +8,10 @@ namespace Assent.Tests
         [Test]
         public void LineEndingDifferencesResultInAFail()
         {
-            new DefaultStringComparer(false)
-                .Compare("A\r\nb", "A\nb")
-                .Passed
-                .Should()
-                .BeFalse();
+            var compareResult = new DefaultStringComparer(false)
+                .Compare("A\r\nb\nc", "A\nb\r\nc");
+            compareResult.Passed.Should().BeFalse();
+            compareResult.Error.Should().Contain("Strings differ only by line endings");
         }
 
         [Test]
@@ -23,6 +22,26 @@ namespace Assent.Tests
                 .Passed
                 .Should()
                 .BeTrue();
+        }
+        
+        [Test]
+        public void OneFileMissingNewLineAtEndOfFileResultInSuccessIfNormaliseLineEndingsIsTrue()
+        {
+            new DefaultStringComparer(true)
+                .Compare("A\nb\nc\n", "A\nb\nc")
+                .Passed
+                .Should()
+                .BeTrue();
+        }
+        
+        [Test]
+        public void OneFileMissingNewLineAtEndOfFileResultInAFail()
+        {
+            new DefaultStringComparer(false)
+                .Compare("A\nb\nc\n", "A\nb\nc")
+                .Passed
+                .Should()
+                .BeFalse();
         }
     }
 }

--- a/src/Assent/DefaultStringComparer.cs
+++ b/src/Assent/DefaultStringComparer.cs
@@ -24,13 +24,21 @@ namespace Assent
 
             if (_normaliseLineEndings)
             {
-                received = received.Replace("\r\n", "\n");
-                approved = approved.Replace("\r\n", "\n");
+                received = received.Replace("\r\n", "\n").TrimEnd('\n');
+                approved = approved.Replace("\r\n", "\n").TrimEnd('\n');
             }
 
             if (received == approved)
                 return CompareResult.Pass();
 
+            if (!_normaliseLineEndings)
+            {
+                var normalisedReceived = received.Replace("\r\n", "\n").TrimEnd('\n');
+                var normalisedApproved = approved.Replace("\r\n", "\n").TrimEnd('\n');
+                if (normalisedReceived == normalisedApproved)
+                    return CompareResult.Fail($"Strings differ only by line endings. Enable 'NormaliseLineEndings' to ignore line ending differences.");
+            }
+            
             var length = Math.Min(approved.Length, received.Length);
             for (var x = 0; x < length; x++)
                 if (approved[x] != received[x])


### PR DESCRIPTION
I had an annoying-to-diagnose error where the only difference was one file had a `\n` on the last line, and one didnt.

This PR:
* if `normaliseLineEndings` is `true`, it trims any trailing `\n`'s from the end of the file
* if `normaliseLineEndings` is `false` _and_ the file only differ by line endings, fails explicitly with an error saying that
