### PR TITLE
Fix minor null-safety issues

### DIFF
--- a/src/Assent.Tests/Assent.Tests.csproj
+++ b/src/Assent.Tests/Assent.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Assent.Tests</AssemblyName>
     <PackageId>Assent.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
+++ b/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
@@ -13,7 +13,7 @@ namespace Assent.Reporters.DiffPrograms
                 Environment.GetEnvironmentVariable("ProgramFiles"),
                 Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
                 Environment.GetEnvironmentVariable("ProgramW6432"),
-                Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "Programs")
+                Environment.GetEnvironmentVariable("LocalAppData") is { } localAppData ? Path.Combine(localAppData, "Programs") : null
             }
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Distinct()
@@ -40,7 +40,7 @@ namespace Assent.Reporters.DiffPrograms
 
             var process = Process.Start(new ProcessStartInfo(
                 path, CreateProcessStartArgs(receivedFile, approvedFile)));
-            process.WaitForExit();
+            process?.WaitForExit();
             return true;
         }
     }

--- a/src/Assent/Reporters/DiffPrograms/EnvironmentVariableDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/EnvironmentVariableDiffProgram.cs
@@ -17,7 +17,7 @@ namespace Assent.Reporters.DiffPrograms
             var args = string.Format(argumentFormat, receivedFile, approvedFile);
             
             var process = Process.Start(new ProcessStartInfo(diffProgram, args));
-            process.WaitForExit();
+            process?.WaitForExit();
             return true;
         }
     }

--- a/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
@@ -21,7 +21,7 @@ namespace Assent.Reporters.DiffPrograms
                 return false;
 
             var process = Process.Start(new ProcessStartInfo(InstallPath, $"-s=\"{approvedFile}\" -d=\"{receivedFile}\""));
-            process.WaitForExit();
+            process?.WaitForExit();
             return true;
         }
     }

--- a/src/Assent/StringReaderWriter.cs
+++ b/src/Assent/StringReaderWriter.cs
@@ -12,8 +12,11 @@ namespace Assent
         public void Write(string filename, string data)
         {
             var dir = Path.GetDirectoryName(filename);
-            if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
+            if (dir is not null)
+            {
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+            }
 
             File.WriteAllText(filename, data);   
         }


### PR DESCRIPTION
# Background

We found during routine use of Assent, that for some reason a windows test agent didn't have the `LocalAppData` environment variable set.

This resulted in a crash in the static initializer, which is quite impactful:

```
System.TypeInitializationException : The type initializer for 'Assent.Reporters.DiffReporter' threw an exception.
---- System.TypeInitializationException : The type initializer for 'Assent.Reporters.DiffPrograms.BeyondCompareDiffProgram' threw an exception.
-------- System.ArgumentNullException : Value cannot be null. (Parameter 'path1')
   at Assent.Reporters.DiffReporter..ctor()
   at Assent.Configuration..ctor()   
```

# Results

This PR fixes `WindowsProgramFilePaths` in `DiffProgramBase` to be tolerant of this env var being null.

It also fixes a few other unlikely null-safety warnings that I found while browsing the code.

It also updates Assent.Tests to target net8.0 so I could run the tests locally (net6 is end of life). If you'd prefer me to take this change out of the PR I'd be happy to