### PR TITLE
Add more safety when getting directory paths from Environment Variables

### DIFF
--- a/src/Assent.Tests/DirPathTests.cs
+++ b/src/Assent.Tests/DirPathTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Assent.Tests;
+
+public static class DirPathTests
+{
+    public class NoSubDirs
+    {
+        [Test]
+        public void SuccessWithValueIfEnvVarSetAndDirExists()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+                getEnvironmentVariable: _ => "localAppDataFolder",
+                directoryExists: _ => true);
+
+            result.Should().BeTrue();
+            value.Should().Be("localAppDataFolder");
+        }
+
+        [Test]
+        public void FailIfEnvVarNotSet()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+                getEnvironmentVariable: _ => null,
+                directoryExists: _ => throw new InvalidOperationException("should not get here"));
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+
+        [Test]
+        public void FailIfEnvVarIsEmpty()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+                getEnvironmentVariable: _ => "",
+                directoryExists: _ => throw new InvalidOperationException("should not get here"));
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+
+        [Test]
+        public void FailIfEnvVarSetAndDirDoesNotExist()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+                getEnvironmentVariable: _ => "localAppDataFolder",
+                directoryExists: _ => false);
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+    }
+    
+    public class CombiningSubDirs
+    {
+        [Test]
+        public void SuccessWithValueIfEnvVarSetAndDirExists()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+                getEnvironmentVariable: _ => "localAppDataFolder",
+                directoryExists: _ => true);
+
+            result.Should().BeTrue();
+            value.Should().Be(Path.Combine("localAppDataFolder", "foo", "bar"));
+        }
+
+        [Test]
+        public void FailIfEnvVarNotSet()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+                getEnvironmentVariable: _ => null,
+                directoryExists: _ => throw new InvalidOperationException("should not get here"));
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+
+        [Test]
+        public void FailIfEnvVarIsEmpty()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+                getEnvironmentVariable: _ => "",
+                directoryExists: _ => throw new InvalidOperationException("should not get here"));
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+
+        [Test]
+        public void FailIfEnvVarSetAndDirDoesNotExist()
+        {
+            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+                getEnvironmentVariable: _ => "localAppDataFolder",
+                directoryExists: d =>
+                {
+                    // it should check the existence of the combined subdir, NOT the base dir
+                    d.Should().Be(Path.Combine("localAppDataFolder", "foo", "bar"));
+                    return false;
+                });
+
+            result.Should().BeFalse();
+            value.Should().BeNull();
+        }
+    }
+}

--- a/src/Assent.Tests/DirPathTests.cs
+++ b/src/Assent.Tests/DirPathTests.cs
@@ -12,44 +12,40 @@ public static class DirPathTests
         [Test]
         public void SuccessWithValueIfEnvVarSetAndDirExists()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", [],
                 getEnvironmentVariable: _ => "localAppDataFolder",
                 directoryExists: _ => true);
 
-            result.Should().BeTrue();
             value.Should().Be("localAppDataFolder");
         }
 
         [Test]
         public void FailIfEnvVarNotSet()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", [],
                 getEnvironmentVariable: _ => null,
                 directoryExists: _ => throw new InvalidOperationException("should not get here"));
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
 
         [Test]
         public void FailIfEnvVarIsEmpty()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", [],
                 getEnvironmentVariable: _ => "",
                 directoryExists: _ => throw new InvalidOperationException("should not get here"));
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
 
         [Test]
         public void FailIfEnvVarSetAndDirDoesNotExist()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", [], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", [],
                 getEnvironmentVariable: _ => "localAppDataFolder",
                 directoryExists: _ => false);
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
     }
@@ -59,40 +55,37 @@ public static class DirPathTests
         [Test]
         public void SuccessWithValueIfEnvVarSetAndDirExists()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", ["foo", "bar"],
                 getEnvironmentVariable: _ => "localAppDataFolder",
                 directoryExists: _ => true);
 
-            result.Should().BeTrue();
             value.Should().Be(Path.Combine("localAppDataFolder", "foo", "bar"));
         }
 
         [Test]
         public void FailIfEnvVarNotSet()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", ["foo", "bar"],
                 getEnvironmentVariable: _ => null,
                 directoryExists: _ => throw new InvalidOperationException("should not get here"));
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
 
         [Test]
         public void FailIfEnvVarIsEmpty()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", ["foo", "bar"],
                 getEnvironmentVariable: _ => "",
                 directoryExists: _ => throw new InvalidOperationException("should not get here"));
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
 
         [Test]
         public void FailIfEnvVarSetAndDirDoesNotExist()
         {
-            var result = DirPath.TryGetFromEnvironment("LOCALAPPDATA", ["foo", "bar"], out var value,
+            var value = DirPath.GetFromEnvironmentOrNull("LOCALAPPDATA", ["foo", "bar"],
                 getEnvironmentVariable: _ => "localAppDataFolder",
                 directoryExists: d =>
                 {
@@ -101,7 +94,6 @@ public static class DirPathTests
                     return false;
                 });
 
-            result.Should().BeFalse();
             value.Should().BeNull();
         }
     }

--- a/src/Assent.Tests/Namers/DefaultNamerFixture.cs
+++ b/src/Assent.Tests/Namers/DefaultNamerFixture.cs
@@ -6,13 +6,22 @@ namespace Assent.Tests.Namers
 {
     public class DefaultNamerFixture
     {
-        [Test]
-        public void NameIsCorrect()
+        [Test, Platform("Win")]
+        public void NameIsCorrectForWindowsPath()
         {
             new DefaultNamer()
                 .GetName(new TestMetadata(this, "MyTest", @"c:\temp\source.cs"))
                 .Should()
                 .Be(@"c:\temp\DefaultNamerFixture.MyTest");
+        }
+
+        [Test, Platform(Exclude = "Win")]
+        public void NameIsCorrectForUnixPath()
+        {
+            new DefaultNamer()
+                .GetName(new TestMetadata(this, "MyTest", "/tmp/source.cs"))
+                .Should()
+                .Be(@"/tmp/DefaultNamerFixture.MyTest");
         }
     }
 }

--- a/src/Assent.Tests/Namers/PostfixNamerFixture.cs
+++ b/src/Assent.Tests/Namers/PostfixNamerFixture.cs
@@ -6,13 +6,22 @@ namespace Assent.Tests.Namers
 {
     public class PostfixNamerFixture
     {
-        [Test]
-        public void NameIsCorrect()
+        [Test, Platform("Win")]
+        public void NameIsCorrectForWindowsPath()
         {
             new PostfixNamer("foo")
                 .GetName(new TestMetadata(this, "MyTest", @"c:\temp\source.cs"))
                 .Should()
                 .Be(@"c:\temp\PostfixNamerFixture.MyTest.foo");
+        }
+
+        [Test, Platform(Exclude = "Win")]
+        public void NameIsCorrectForUnixPath()
+        {
+            new PostfixNamer("foo")
+                .GetName(new TestMetadata(this, "MyTest", "/tmp/source.cs"))
+                .Should()
+                .Be("/tmp/PostfixNamerFixture.MyTest.foo");
         }
     }
 }

--- a/src/Assent.Tests/Namers/SubdirectoryNamerFixture.cs
+++ b/src/Assent.Tests/Namers/SubdirectoryNamerFixture.cs
@@ -6,22 +6,40 @@ namespace Assent.Tests.Namers
 {
     public class SubdirectoryNamerFixture
     {
-        [Test]
-        public void NameIsCorrect()
+        [Test, Platform("Win")]
+        public void NameIsCorrectForWindowsPath()
         {
             new SubdirectoryNamer("SubDir")
                 .GetName(new TestMetadata(this, "MyTest", @"c:\temp\source.cs"))
                 .Should()
                 .Be(@"c:\temp\SubDir\SubdirectoryNamerFixture.MyTest");
         }
+        
+        [Test, Platform(Exclude = "Win")]
+        public void NameIsCorrectForUnixPath()
+        {
+            new SubdirectoryNamer("SubDir")
+                .GetName(new TestMetadata(this, "MyTest", "/tmp/source.cs"))
+                .Should()
+                .Be("/tmp/SubDir/SubdirectoryNamerFixture.MyTest");
+        }
 
-        [Test]
-        public void NameIsCorrectWithPostfix()
+        [Test, Platform("Win")]
+        public void NameIsCorrectWithPostfixForWindowsPath()
         {
             new SubdirectoryNamer("SubDir", "foo")
                 .GetName(new TestMetadata(this, "MyTest", @"c:\temp\source.cs"))
                 .Should()
                 .Be(@"c:\temp\SubDir\SubdirectoryNamerFixture.MyTest.foo");
+        }
+        
+        [Test, Platform(Exclude = "Win")]
+        public void NameIsCorrectWithPostfixForUnixPath()
+        {
+            new SubdirectoryNamer("SubDir", "foo")
+                .GetName(new TestMetadata(this, "MyTest", "/tmp/source.cs"))
+                .Should()
+                .Be("/tmp/SubDir/SubdirectoryNamerFixture.MyTest.foo");
         }
     }
 }

--- a/src/Assent/Assent.csproj
+++ b/src/Assent/Assent.csproj
@@ -11,5 +11,6 @@
     <PackageProjectUrl>https://github.com/droyad/Assent</PackageProjectUrl>
     <RepositoryUrl>https://github.com/droyad/Assent</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/droyad/Assent/blob/master/LICENCE.md</PackageLicenseUrl>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Assent/DirPath.cs
+++ b/src/Assent/DirPath.cs
@@ -1,56 +1,34 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 
 namespace Assent
 {
     internal static class DirPath
     {
         /// <summary>
-        /// Reads the environment variable defined by `name`, and checks that it exists using Directory.Exists.
-        /// If no such directory exists, will return false and `value` will be null. If it does exist, will return true and `value` will be the environment variable value.
-        /// </summary>
-        internal static bool TryGetFromEnvironment(string name, [MaybeNullWhen(returnValue: false)] out string value)
-            => TryGetFromEnvironment(name, Array.Empty<string>(), out value);
-
-        /// <summary>
         /// Reads the environment variable defined by `name`, appends the given subdirectories from `combineSubDirs` and checks that it exists using Directory.Exists.
-        /// If no such directory exists, will return false and `value` will be null. If it does exist, will return true and `value` will be the environment variable value.
+        /// If no such directory exists, will return null. If it does exist, will return the environment variable value.
         /// </summary>
-        internal static bool TryGetFromEnvironment(string name, string[] combineSubDirs, [MaybeNullWhen(returnValue: false)] out string value)
-            => TryGetFromEnvironment(name, combineSubDirs, out value, Environment.GetEnvironmentVariable, Directory.Exists);
+        internal static string GetFromEnvironmentOrNull(string name, params string[] combineSubDirs)
+            => GetFromEnvironmentOrNull(name, combineSubDirs, Environment.GetEnvironmentVariable, Directory.Exists);
 
         // This method allows injected I/O functions for unit testing. Don't call it outside of tests
-        internal static bool TryGetFromEnvironment(
+        internal static string GetFromEnvironmentOrNull(
             string name,
             string[] combineSubDirs,
-            [MaybeNullWhen(returnValue: false)] out string value,
             Func<string, string> getEnvironmentVariable,
             Func<string, bool> directoryExists)
         {
-            var valueFromEnv = getEnvironmentVariable(name);
-            if (string.IsNullOrWhiteSpace(valueFromEnv))
-            {
-                value = null;
-                return false;
-            }
+            var pathFromEnv = getEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(pathFromEnv))
+                return null;
 
-            if (combineSubDirs is { Length: > 0 })
-            {
-                var components = new string[combineSubDirs.Length + 1];
-                components[0] = valueFromEnv;
-                Array.Copy(combineSubDirs, 0, components, 1, combineSubDirs.Length);
-                value = Path.Combine(components);
-            }
-            else
-            {
-                value = valueFromEnv;
-            }
+            var pathWithSubDirs = Path.Combine(new[] {pathFromEnv}.Concat(combineSubDirs).ToArray());
 
-            if (directoryExists(value)) return true;
-
-            value = null;
-            return false;
+            return directoryExists(pathWithSubDirs) 
+                ? pathWithSubDirs 
+                : null;
         }
     }
 }

--- a/src/Assent/DirPath.cs
+++ b/src/Assent/DirPath.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Assent
+{
+    internal static class DirPath
+    {
+        /// <summary>
+        /// Reads the environment variable defined by `name`, and checks that it exists using Directory.Exists.
+        /// If no such directory exists, will return false and `value` will be null. If it does exist, will return true and `value` will be the environment variable value.
+        /// </summary>
+        internal static bool TryGetFromEnvironment(string name, [MaybeNullWhen(returnValue: false)] out string value)
+            => TryGetFromEnvironment(name, Array.Empty<string>(), out value);
+
+        /// <summary>
+        /// Reads the environment variable defined by `name`, appends the given sub-directories from `combineSubDirs` and checks that it exists using Directory.Exists.
+        /// If no such directory exists, will return false and `value` will be null. If it does exist, will return true and `value` will be the environment variable value.
+        /// </summary>
+        internal static bool TryGetFromEnvironment(string name, string[] combineSubDirs, [MaybeNullWhen(returnValue: false)] out string value)
+        {
+            var valueFromEnv = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(valueFromEnv))
+            {
+                value = null;
+                return false;
+            }
+
+            if (combineSubDirs is { Length: > 0 })
+            {
+                var components = new string[combineSubDirs.Length + 1];
+                components[0] = valueFromEnv;
+                Array.Copy(combineSubDirs, 0, components, 1, combineSubDirs.Length);
+                value = Path.Combine(components);
+            }
+            else
+            {
+                value = valueFromEnv;
+            }
+
+            if (Directory.Exists(value)) return true;
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/BeyondCompareDiffProgram.cs
@@ -11,7 +11,7 @@ namespace Assent.Reporters.DiffPrograms
             var paths = new List<string>();
             if (DiffReporter.IsWindows)
             {
-                paths.AddRange(WindowsProgramFilePaths
+                paths.AddRange(WindowsProgramFilePaths()
                     .SelectMany(p =>
                         new[]
                         {

--- a/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
+++ b/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
@@ -8,16 +8,17 @@ namespace Assent.Reporters.DiffPrograms
 {
     public abstract class DiffProgramBase : IDiffProgram
     {
-        protected static IReadOnlyList<string> WindowsProgramFilePaths => new[]
-            {
-                Environment.GetEnvironmentVariable("ProgramFiles"),
-                Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
-                Environment.GetEnvironmentVariable("ProgramW6432"),
-                Environment.GetEnvironmentVariable("LocalAppData") is string localAppData ? Path.Combine(localAppData, "Programs") : null
-            }
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .Distinct()
-            .ToArray();
+        protected static IReadOnlyList<string> WindowsProgramFilePaths()
+        {
+            var result = new List<string>();
+            
+            if (DirPath.TryGetFromEnvironment("ProgramFiles", out var pf)) result.Add(pf);
+            if (DirPath.TryGetFromEnvironment("ProgramFiles(x86)", out var pf86)) result.Add(pf86);
+            if (DirPath.TryGetFromEnvironment("ProgramW6432", out var pfw64)) result.Add(pfw64);
+            if (DirPath.TryGetFromEnvironment("LocalAppData", new[] { "Programs" }, out var appDataPrograms)) result.Add(appDataPrograms);
+
+            return result.Distinct().ToList();
+        }
 
         public IReadOnlyList<string> SearchPaths { get; }
 

--- a/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
+++ b/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
@@ -13,11 +13,13 @@ namespace Assent.Reporters.DiffPrograms
             var result = new List<string>();
             
             if (DirPath.TryGetFromEnvironment("ProgramFiles", out var pf)) result.Add(pf);
-            if (DirPath.TryGetFromEnvironment("ProgramFiles(x86)", out var pf86)) result.Add(pf86);
-            if (DirPath.TryGetFromEnvironment("ProgramW6432", out var pfw64)) result.Add(pfw64);
+            
+            if (DirPath.TryGetFromEnvironment("ProgramFiles(x86)", out var pf86) && !result.Contains(pf86)) result.Add(pf86);
+            if (DirPath.TryGetFromEnvironment("ProgramW6432", out var pfw64) && !result.Contains(pfw64)) result.Add(pfw64);
+            
             if (DirPath.TryGetFromEnvironment("LocalAppData", new[] { "Programs" }, out var appDataPrograms)) result.Add(appDataPrograms);
 
-            return result.Distinct().ToList();
+            return result;
         }
 
         public IReadOnlyList<string> SearchPaths { get; }

--- a/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
+++ b/src/Assent/Reporters/DiffPrograms/DiffProgramBase.cs
@@ -10,16 +10,15 @@ namespace Assent.Reporters.DiffPrograms
     {
         protected static IReadOnlyList<string> WindowsProgramFilePaths()
         {
-            var result = new List<string>();
-            
-            if (DirPath.TryGetFromEnvironment("ProgramFiles", out var pf)) result.Add(pf);
-            
-            if (DirPath.TryGetFromEnvironment("ProgramFiles(x86)", out var pf86) && !result.Contains(pf86)) result.Add(pf86);
-            if (DirPath.TryGetFromEnvironment("ProgramW6432", out var pfw64) && !result.Contains(pfw64)) result.Add(pfw64);
-            
-            if (DirPath.TryGetFromEnvironment("LocalAppData", new[] { "Programs" }, out var appDataPrograms)) result.Add(appDataPrograms);
+            var result = new[]
+            {
+                DirPath.GetFromEnvironmentOrNull("ProgramFiles"),
+                DirPath.GetFromEnvironmentOrNull("ProgramFiles(x86)"),
+                DirPath.GetFromEnvironmentOrNull("ProgramW6432"),
+                DirPath.GetFromEnvironmentOrNull("LocalAppData", "Programs")
+            };
 
-            return result;
+            return result.Where(r => r != null).ToArray();
         }
 
         public IReadOnlyList<string> SearchPaths { get; }

--- a/src/Assent/Reporters/DiffPrograms/KDiff3DiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/KDiff3DiffProgram.cs
@@ -8,7 +8,7 @@ namespace Assent.Reporters.DiffPrograms
     {
         static KDiff3DiffProgram()
         {
-            DefaultSearchPaths = WindowsProgramFilePaths
+            DefaultSearchPaths = WindowsProgramFilePaths()
                 .Select(p => $@"{p}\KDiff3\KDiff3.exe")
                 .ToArray();
         }

--- a/src/Assent/Reporters/DiffPrograms/MeldDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/MeldDiffProgram.cs
@@ -12,7 +12,7 @@ public class MeldDiffProgram : DiffProgramBase
         var paths = new List<string>();
         if (DiffReporter.IsWindows)
         {
-            paths.AddRange(WindowsProgramFilePaths
+            paths.AddRange(WindowsProgramFilePaths()
                 .Select(p => $@"{p}\Meld\Meld.exe")
                 .ToArray());
         }

--- a/src/Assent/Reporters/DiffPrograms/P4MergeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/P4MergeDiffProgram.cs
@@ -8,7 +8,7 @@ namespace Assent.Reporters.DiffPrograms
     {
         static P4MergeDiffProgram()
         {
-            DefaultSearchPaths = WindowsProgramFilePaths
+            DefaultSearchPaths = WindowsProgramFilePaths()
                 .Select(p => $@"{p}\Perforce\p4merge.exe")
                 .ToArray();
         }

--- a/src/Assent/Reporters/DiffPrograms/RiderDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/RiderDiffProgram.cs
@@ -12,17 +12,18 @@ public class RiderDiffProgram : DiffProgramBase
 
     static RiderDiffProgram()
     {
-        var riderChannelsDirectory = Environment.GetEnvironmentVariable("LocalAppData") + "\\JetBrains\\Toolbox\\apps\\Rider\\";
-        if (!Directory.Exists(riderChannelsDirectory))
+        if (!DirPath.TryGetFromEnvironment("LocalAppData", new[] { "JetBrains", "Toolbox", "apps", "Rider" }, out var riderChannelsDirectory))
         {
-            DefaultSearchPaths = new List<string>();
+            DefaultSearchPaths = Array.Empty<string>();
             return;
         }
 
         DefaultSearchPaths = Directory.GetDirectories(riderChannelsDirectory).Select(GetRiderExePathInChannel).ToList();
     }
 
-    public RiderDiffProgram() : base(DefaultSearchPaths) { }
+    public RiderDiffProgram() : base(DefaultSearchPaths)
+    {
+    }
 
     protected override string CreateProcessStartArgs(string receivedFile, string approvedFile) =>
         $"\"diff\" \"{receivedFile}\" \"{approvedFile}\"";

--- a/src/Assent/Reporters/DiffPrograms/RiderDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/RiderDiffProgram.cs
@@ -12,9 +12,10 @@ public class RiderDiffProgram : DiffProgramBase
 
     static RiderDiffProgram()
     {
-        if (!DirPath.TryGetFromEnvironment("LocalAppData", new[] { "JetBrains", "Toolbox", "apps", "Rider" }, out var riderChannelsDirectory))
+        var riderChannelsDirectory = DirPath.GetFromEnvironmentOrNull("LocalAppData", "JetBrains", "Toolbox", "apps", "Rider");
+        if (riderChannelsDirectory == null)
         {
-            DefaultSearchPaths = Array.Empty<string>();
+            DefaultSearchPaths = [];
             return;
         }
 

--- a/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/VsCodeDiffProgram.cs
@@ -11,7 +11,7 @@ namespace Assent.Reporters.DiffPrograms
             var paths = new List<string>();
             if (DiffReporter.IsWindows)
             {
-                paths.AddRange(WindowsProgramFilePaths
+                paths.AddRange(WindowsProgramFilePaths()
                     .Select(p => $@"{p}\Microsoft VS Code\Code.exe")
                     .ToArray());
             }

--- a/src/Assent/Reporters/DiffPrograms/WinMergeDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/WinMergeDiffProgram.cs
@@ -7,7 +7,7 @@ namespace Assent.Reporters.DiffPrograms
     {
         static WinMergeDiffProgram()
         {
-            DefaultSearchPaths = WindowsProgramFilePaths
+            DefaultSearchPaths = WindowsProgramFilePaths()
                 .Select(p => $@"{p}\WinMerge\WinMergeU.exe")
                 .ToArray();
         }

--- a/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
@@ -9,8 +9,14 @@ namespace Assent.Reporters.DiffPrograms
     {
         static XdiffDiffProgram()
         {
-            var appData = Environment.GetEnvironmentVariable("LocalAppData");
-            InstallPath = Path.Combine(appData, "semanticmerge\\mergetool.exe");
+            if (DirPath.TryGetFromEnvironment("LocalAppData", new[] { "semanticmerge " }, out var semanticMergeDir))
+            {
+                InstallPath = Path.Combine(semanticMergeDir, "mergetool.exe");
+            }
+            else
+            {
+                InstallPath = ""; // File.Exists always returns false for empty-string
+            }
         }
 
         public static readonly string InstallPath;

--- a/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
+++ b/src/Assent/Reporters/DiffPrograms/XdiffDiffProgram.cs
@@ -9,7 +9,8 @@ namespace Assent.Reporters.DiffPrograms
     {
         static XdiffDiffProgram()
         {
-            if (DirPath.TryGetFromEnvironment("LocalAppData", new[] { "semanticmerge " }, out var semanticMergeDir))
+            var semanticMergeDir = DirPath.GetFromEnvironmentOrNull("LocalAppData", "semanticmerge");
+            if (semanticMergeDir != null)
             {
                 InstallPath = Path.Combine(semanticMergeDir, "mergetool.exe");
             }


### PR DESCRIPTION
# Background

In [Minor null safety fixes](https://github.com/droyad/Assent/pull/46), the code in `DiffProgramBase` was improved so it did not crash when `Environment.GetEnvironmentVariable("LocalAppData")` returned null.

However, we recently received more crashes from `Assent.Reporters.DiffPrograms.XdiffDiffProgram`, which contains the same bug and I missed it during the previous fix.

```
System.TypeInitializationException : The type initializer for 'Assent.Reporters.DiffReporter' threw an exception.
---- System.TypeInitializationException : The type initializer for 'Assent.Reporters.DiffPrograms.XdiffDiffProgram' threw an exception.
-------- System.ArgumentNullException : Value cannot be null. (Parameter 'path1')
   at Assent.Reporters.DiffReporter..ctor()
   at Assent.Configuration..ctor()
```

# Results

This PR attempts to make a more comprehensive fix:

There is now a `DirPath` class with `TryGetFromEnvironment` methods, which will read the environment variable, optionally combine any desired subdirectories, and then _check the path exists_. Code that calls it can guarantee a valid path in the case of `returnValue: true`.

I then searched for all calls to `GetEnvironmentVariable` and updated them to use `DirPath.TryGetFromEnvironment` as appropriate.

Drive-by fix. The `Namer` unit tests did not pass on macOS as they used `c:\temp`. I've used NUnit's Platform attribute to only run those on Windows, and added non-windows variants.

